### PR TITLE
Buildable in GHC 7.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .cabal-sandbox/
 cabal.sandbox.config
 dist/
+stack.yaml
+.stack-work

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ naver-translate
 Haskell interface to [Naver Translate][1].  Note that Naver Translate doesn't
 provide any official API.
 
+    > :set -XOverloadedStrings
     > import Language.Translate.Naver (translate)
-    > import Language.LanguageCodes (ISO639_1(JA, KO))
+    > import Data.LanguageCodes (ISO639_1(JA, KO))
+    > import Data.Text (unpack)
     > result <- translate KO JA "안녕하세요."
-    > result
-    "こんにちは"
+    > putStrLn (unpack result)
+    こんにちは
 
 Written by [Hong Minhee][2] and distributed under [GPLv3][3] or higher.
 See also LICENSE file.

--- a/naver-translate.cabal
+++ b/naver-translate.cabal
@@ -15,14 +15,14 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Language.Translate.Naver
-  build-depends:       aeson        >=0.7.0.6  && <0.8.0.0,
-                       base         >=4.7 && <4.8,
+  build-depends:       aeson        >=0.7.0.6  && <0.9.0.0,
+                       base         >=4.7 && <4.9,
                        iso639,
-                       lens         >=4.8 && <4.9,
+                       lens         >=4.8 && <4.13,
                        lens-aeson   >=1.0.0.3  && <1.1.0.0,
                        network-uri  >=2.6.0.0  && <3.0.0.0,
-                       text         >=1.1.0.0  && <1.2.0.0,
-                       wreq         >=0.3.0.1  && <0.4.0.0,
+                       text         >=1.1.0.0  && <1.2.2.0,
+                       wreq         >=0.3.0.1  && <0.5.0.0,
                        random       >=1.0.1.1  && <1.1.0.0
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Language/Translate/Naver.hs
+++ b/src/Language/Translate/Naver.hs
@@ -10,7 +10,7 @@ import Data.Aeson.Lens (key)
 import Data.Aeson.Types (Value(String))
 import Data.LanguageCodes (ISO639_1(JA, KO), language)
 import Data.Text (Text, cons, intercalate, pack, snoc, splitOn, strip)
-import Network.URI (URI(URI), URIAuth(URIAuth), relativeTo, uriIsAbsolute)
+import Network.URI (URI(URI), URIAuth(URIAuth), relativeTo)
 import Network.Wreq (FormParam((:=)), post, responseBody)
 import System.Random (getStdRandom, randomR)
 


### PR DESCRIPTION
This enables to be built with ghc 7.10. It was checked using ghc 7.10.2 and packages in [LTS Haskell 3.9](https://www.stackage.org/lts-3.9). I guess that building using ghc 7.8 does not be affected by this (not tested).

Additionally, `README.md` is fixed to show the test in ghci correctly, and a redundant import is removed.
